### PR TITLE
Expose controller buttons while hand-tracking is active

### DIFF
--- a/src/televuer/televuer.py
+++ b/src/televuer/televuer.py
@@ -92,8 +92,12 @@ class TeleVuer:
         self.vuer.add_handler("CAMERA_MOVE")(self.on_cam_move)
         if self.use_hand_tracking:
             self.vuer.add_handler("HAND_MOVE")(self.on_hand_move)
-        else:
-            self.vuer.add_handler("CONTROLLER_MOVE")(self.on_controller_move)
+        # Always register CONTROLLER_MOVE, even in hand-tracking mode: this lets Quest 3
+        # controller buttons (A/B/X/Y, trigger, squeeze, thumbstick) keep reporting state for
+        # state-machine control (READY/Recording/Quit) while hand tracking still drives wrist
+        # pose. on_controller_move() below skips its arm-pose writes when use_hand_tracking is
+        # True, so it never fights with on_hand_move()'s pose writes.
+        self.vuer.add_handler("CONTROLLER_MOVE")(self.on_controller_move)
 
         self.display_mode = display_mode
         self.zmq = zmq
@@ -229,11 +233,14 @@ class TeleVuer:
     async def on_controller_move(self, event, session, fps=60):
         """https://docs.vuer.ai/en/latest/examples/20_motion_controllers.html"""
         try:
-            # ControllerData
-            with self.left_arm_pose_shared.get_lock():
-                self.left_arm_pose_shared[:] = event.value["left"]
-            with self.right_arm_pose_shared.get_lock():
-                self.right_arm_pose_shared[:] = event.value["right"]
+            # ControllerData. Skip when hand tracking owns wrist pose, so this handler (now
+            # always registered, to also catch button presses in hand-tracking mode) never
+            # overwrites the arm pose that on_hand_move() is driving.
+            if not self.use_hand_tracking:
+                with self.left_arm_pose_shared.get_lock():
+                    self.left_arm_pose_shared[:] = event.value["left"]
+                with self.right_arm_pose_shared.get_lock():
+                    self.right_arm_pose_shared[:] = event.value["right"]
             # ControllerState
             left_controller = event.value["leftState"]
             right_controller = event.value["rightState"]

--- a/src/televuer/tv_wrapper.py
+++ b/src/televuer/tv_wrapper.py
@@ -412,6 +412,13 @@ class TeleVuerWrapper:
                 right_hand_pinchValue=self.tvuer.right_hand_pinchValue * 100.0,
                 right_hand_squeeze=self.tvuer.right_hand_squeeze,
                 right_hand_squeezeValue=self.tvuer.right_hand_squeezeValue,
+                # Controller face buttons, forwarded even though wrist pose comes from hand
+                # tracking here. Requires the patched TeleVuer.on_controller_move (always
+                # registers CONTROLLER_MOVE) so these shared values keep updating in hand mode.
+                left_ctrl_aButton=self.tvuer.left_ctrl_aButton,
+                left_ctrl_bButton=self.tvuer.left_ctrl_bButton,
+                right_ctrl_aButton=self.tvuer.right_ctrl_aButton,
+                right_ctrl_bButton=self.tvuer.right_ctrl_bButton,
             )
         # controller tracking
         else:


### PR DESCRIPTION
Why: this one of a few PRs to enable the teleoperate control via Quest 3 controllers, e.g. start syncing, toggling recording, quit program.

televuer previously registered either HAND_MOVE or CONTROLLER_MOVE based on use_hand_tracking, never both, so Quest 3 controller button presses (A/B/X/Y) were silently dropped whenever hand tracking drove arm IK.

- televuer.py: always register CONTROLLER_MOVE; on_controller_move now skips its arm-pose writes when use_hand_tracking is True, so it never fights with on_hand_move's wrist-pose writes. Button/trigger/ squeeze/thumbstick extraction and the motion_data_ready write are unchanged and now always run.
- tv_wrapper.py: thread left/right_ctrl_aButton/bButton into the hand-tracking branch of get_tele_data()'s TeleData(...) construction, reusing the same self.tvuer reads the controller branch already uses.

This lets a consumer (e.g. xr_teleoperate's teleop_hand_and_arm.py) use Quest 3 controller buttons for out-of-band session control (state transitions, recording toggle, quit) even when --input-mode hand is selected for arm/hand IK.